### PR TITLE
Set to C99 and use implicit rule for compilation

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 CC=gcc
 CFLAGS=-Wall
-LIBS=-lncursesw
+CFLAGS+=-std=c99
+LDLIBS=-lncursesw
 TARGET=snow
 
 all: $(TARGET)
@@ -9,7 +10,6 @@ debug: CFLAGS += -DDEBUG -ggdb3
 debug: $(TARGET)
 
 $(TARGET): $(TARGET).c
-	$(CC) -o $(TARGET) $(TARGET).c $(CFLAGS) $(LIBS) 
 
 .PHONY : clean
 clean:


### PR DESCRIPTION
For compilers not default to C99 (or later), a warning from GCC 4.9.3:

    snow.c:23:2: warning: universal character names are only valid in C++ and C99
      L"\u2744",
      ^